### PR TITLE
add info on interactive jobs

### DIFF
--- a/content/pages/medusa/code_of_conduct.rst
+++ b/content/pages/medusa/code_of_conduct.rst
@@ -13,9 +13,13 @@ and empathy for the work of others. Specific points to pay attention to are:
 Use Condor for analysis
   All computational jobs are to be submitted to the HTCondor queue. The head
   node is meant for interactive use and quick computations, otherwise it
-  negatively affects other people's work.  HTCondor Job descriptions should
-  be accurate, and users should make an honest intellectual effort to adapt
-  their jobs to the mythical `"ideal job" </medusa/htcondor/#the "ideal" job>`_.
+  negatively affects other people's work. Anything bigger should be submitted as
+  a HTCondor Job, either as an
+  `interactive job </medusa/htcondor/#the-interactive-jobs>`_ or as a
+  `non-interactive job </medusa/htcondor/#the "ideal" job>`_. HTCondor Job
+  descriptions should  be accurate, and users should make an honest intellectual
+  effort to adapt their jobs to the mythical
+  `"ideal job" </medusa/htcondor/#the "ideal" job>`_.
 
 Be mindful of your storage space
   Treat storage space as if it's a finite resource (pro-tip: it is).

--- a/content/pages/medusa/htcondor.rst
+++ b/content/pages/medusa/htcondor.rst
@@ -6,6 +6,9 @@ This document focuses on how HTCondor is configured and intended to be used on
 our cluster. To learn about Condor and how to use it, you should read the
 `Tools > HTCondor </tools/htcondor/>`_ page.
 
+HTCondor jobs come in two versions: interactive and non-interactive. Whenever
+possible, a non-interactive job should be used for computations.
+
 .. class:: todo
 
   **TODO:** This page needs some love.
@@ -32,6 +35,15 @@ merely rewarding those who submit jobs first.
 
 10,000 jobs lasting 1 hour each is *far* better than 1,000 jobs lasting 10 hours
 each.
+
+The Interactive Jobs
+********************
+Any task which takes more than a few minutes or uses a lot of CPU/RAM should
+*not* be run from the head node, but as an interactive job. This applies
+especially to working with `datalad </tools/datalad>`_, as the underlying
+``git annex`` calls can be very CPU-intense. To run an interactive job, use the
+following `job submit file </tools/htcondor#interactive-jobs>`_.
+
 
 Prioritization of Jobs
 **********************
@@ -109,6 +121,13 @@ released (2019a and newer) is most appreciated.
   **TODO:** Discuss Matlab Compiler
 
 .. _maxNumCompThreads(): https://www.mathworks.com/help/matlab/ref/maxnumcompthreads.html
+
+fMRIPrep
+********
+
+By default, fMRIPrep will use all available CPUs & all the RAM it can get. Use
+the ``--nthreads`` and ``--mem-mb`` to limit its usage to the requested
+resources.
 
 Intel vs AMD
 ************

--- a/content/pages/tools/datalad.rst
+++ b/content/pages/tools/datalad.rst
@@ -5,6 +5,12 @@ DataLad
 DataLad is a data management tool to share, search, obtain, extend, and version
 data.
 
+Beware that the underlying ``git annex`` calls (e.g. when calling
+``datalad save``) can be very CPU-intense once a dataset contains many files
+(e.g. a typical fMRI dataset). Thus, it is important to work on such datasets
+via an `interactive job </medusa/htcondor#The interactive job>`_.
+
+
 Resources
 *********
 

--- a/content/pages/tools/htcondor.rst
+++ b/content/pages/tools/htcondor.rst
@@ -261,7 +261,7 @@ To work interactively on a compute node instead of the head node, there are two
 ways:
 
 1. run a default interactive job with ``condor_submit -interactive``, i.e.
-  without specifying any submit-file.
+   without specifying any submit-file.
 
 2. submitting a job which can specify additional, non-default values.
 

--- a/content/pages/tools/htcondor.rst
+++ b/content/pages/tools/htcondor.rst
@@ -201,7 +201,7 @@ Breaking this into sections:
 
 Generating a .submit
 ********************
-Condor's strength is not running one job at a time. It's strength is running
+Condor's strength is not running one job at a time. Its strength is running
 thousands of jobs at a time, and no one in their right mind writes such submit
 files by hand. A simple script is used to generate them.
 
@@ -253,6 +253,62 @@ If everything looks good, then it's time to submit the jobs directly to condor.
   ./ncal_submit_gen.sh | condor_submit
 
 And you just submitted 1,000 jobs to condor.
+
+
+Interactive Jobs
+****************
+To work interactively on a compute node instead of the head node, there are two
+ways:
+
+1. run a default interactive job with ``condor_submit -interactive``, i.e.
+  without specifying any submit-file.
+
+2. submitting a job which can specify additional, non-default values.
+
+An example submit file for an interactive job is:
+
+.. code::
+
+    # The environment
+    # the universe is always vanilla for interactive jobs
+    # universe = vanilla
+    getenv         = True
+
+    # per default, an interactive job will end if you do not use the session for
+    # more than 2 hours. When using a submit file, this would be overwritten to
+    # "never", so we manually specify it again.
+    environment    = "TMOUT=7200"
+
+    # Required Resources
+    request_cpus   = 1
+    request_memory = 4G
+
+    # Execution
+    initial_dir    = $ENV(HOME)
+    executable     = /bin/bash
+
+    # Logs
+    log     = $ENV(HOME)/logs/$(Cluster).$(Process).log
+    output  = $ENV(HOME)/logs/$(Cluster).$(Process).out
+    error   = $ENV(HOME)/logs/$(Cluster).$(Process).err
+
+    # Job - will only spawn one instance no matter what
+    Queue
+
+
+.. class:: note
+
+  **NOTE:** An interactive session is blocking the requested CPU(s) and memory
+  for your use, potentially preventing others to run their jobs. If you do not
+  plan to work within the next 1-2 hours using the interactive session, ``exit``
+  it and resubmit a new interactive job later again.
+
+
+For long-running processes (e.g. importing dicoms using ``datalad-hirni``), you
+should start this interactive job from a `tmux session </tools/tmux>`_. That is,
+you should log into the head node as usual, start ``tmux`` and then start the
+interactive session. This way, the interactive session will be part of your tmux
+session, which you can detach and re-attach later.
 
 
 Useful Commands


### PR DESCRIPTION
added text in multiple places, so that no matter where people start reading, they would find info on the interactive jobs. At the same time, tried to stick to the logical structure of general info vs how-to. 

bonus: added warning on fMRIPrep and CPU/RAM grabbing and how to avoid it.

plus fixed one typo :)