### PR TITLE
Fix pelican-toc to work with pelican 4.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ help:
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
 	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
 	@echo '                                                                          '
-
-html:
+html: pelican-toc.patched
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
 	if test -d $(BASEDIR)/static; then rsync -rv $(BASEDIR)/static/ $(OUTPUTDIR)/; fi
 
@@ -40,7 +39,7 @@ clean:
 	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)
 	pyclean ./
 
-devserver:
+devserver: pelican-toc.patched
 	if test -d $(BASEDIR)/static; then rsync -rv $(BASEDIR)/static/ $(OUTPUTDIR)/; fi
 ifdef PORT
 	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT)
@@ -48,9 +47,11 @@ else
 	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
 endif
 
-publish:
+publish: pelican-toc.patched
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 	if test -d $(BASEDIR)/static; then rsync -rv $(BASEDIR)/static/ $(OUTPUTDIR)/; fi
 
+pelican-toc.patched: pelican-toc.patch
+	patch --forward -d ./pelican-plugins/pelican-toc/ < pelican-toc.patch || true
 
 .PHONY: html help clean devserver stopserver publish

--- a/pelican-toc.patch
+++ b/pelican-toc.patch
@@ -1,0 +1,14 @@
+diff --git a/pelican-plugins/pelican-toc/toc.py b/pelican-plugins/pelican-toc/toc.py
+index 3a4699d..9be60ae 100644
+--- a/pelican-plugins/pelican-toc/toc.py
++++ b/pelican-plugins/pelican-toc/toc.py
+@@ -13,7 +13,8 @@ import re
+ from bs4 import BeautifulSoup, Comment
+ 
+ from pelican import contents, signals
+-from pelican.utils import python_2_unicode_compatible, slugify
++from pelican.utils import slugify
++from six import python_2_unicode_compatible
+ 
+ 
+ logger = logging.getLogger(__name__)


### PR DESCRIPTION
Since python2 support was removed in pelican 4.5.0 pelican-toc does not work any more and thus the IPSY Docs as well.
The error message is:
```
ERROR: Cannot load plugin `pelican-toc`
  | cannot import name 'python_2_unicode_compatible' from 'pelican.utils' (~/.venvs/pelican/lib64/python3.8/site-packages/pelican/utils.py)
CRITICAL: Error encountered
```
A quick and easy fix is to load python_2_unicode_compatible inside pelican-toc from the six module instead.